### PR TITLE
no package named nss-mdns.i?86 on redhat

### DIFF
--- a/avahi/map.jinja
+++ b/avahi/map.jinja
@@ -5,7 +5,7 @@
     'config'  : '/etc/avahi/avahi-daemon.conf',
   },
   'RedHat' : {
-    'pkgs'    : ['avahi','avahi-autoipd','avahi-compat-libdns_sd','avahi-glib','avahi-gobject','avahi-tools','nss-mdns','nss-mdns.i?86'],
+    'pkgs'    : ['avahi','avahi-autoipd','avahi-compat-libdns_sd','avahi-glib','avahi-gobject','avahi-tools','nss-mdns',],
     'service' : 'avahi-daemon',
     'config'  : '/etc/avahi/avahi-daemon.conf',
   },


### PR DESCRIPTION
```
No package nss-mdns.i?86 available.
```